### PR TITLE
fix(LinkService): execute to get errors from netlink

### DIFF
--- a/link.go
+++ b/link.go
@@ -108,8 +108,8 @@ const (
 
 // New creates a new interface using the LinkMessage information.
 func (l *LinkService) New(req *LinkMessage) error {
-	flags := netlink.HeaderFlagsRequest
-	_, err := l.c.Send(req, RTM_SETLINK, flags)
+	flags := netlink.HeaderFlagsRequest | netlink.HeaderFlagsCreate | netlink.HeaderFlagsAcknowledge | netlink.HeaderFlagsExcl
+	_, err := l.c.Execute(req, RTM_NEWLINK, flags)
 	if err != nil {
 		return err
 	}
@@ -123,8 +123,8 @@ func (l *LinkService) Delete(index uint32) error {
 		Index: index,
 	}
 
-	flags := netlink.HeaderFlagsRequest
-	_, err := l.c.Send(req, RTM_DELLINK, flags)
+	flags := netlink.HeaderFlagsRequest | netlink.HeaderFlagsAcknowledge
+	_, err := l.c.Execute(req, RTM_DELLINK, flags)
 	if err != nil {
 		return err
 	}
@@ -154,8 +154,8 @@ func (l *LinkService) Get(index uint32) (LinkMessage, error) {
 
 // Set sets interface attributes according to the LinkMessage information.
 func (l *LinkService) Set(req *LinkMessage) error {
-	flags := netlink.HeaderFlagsRequest
-	_, err := l.c.Send(req, RTM_SETLINK, flags)
+	flags := netlink.HeaderFlagsRequest | netlink.HeaderFlagsAcknowledge
+	_, err := l.c.Execute(req, RTM_SETLINK, flags)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Without calling receive on the netlink socket, we never get error
messages (such as EEXIST or EOPNOTSUPP) from the kernel rtnetlink
implementation. Without these errors, applications using LinkService may
continue with the assumption no errors occurred.

This change modifies the LinkService implementation to call the netlink
library's Execute method, which both sends our message, as well as
receives the response.

This change also modifies the message sent by New to be of type
RTM_NEWLINK, so the kernel knows to create a new link.