### PR TITLE
chore: install golint from canonical location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ go:
 os:
   - linux
 before_install:
-  - go get github.com/golang/lint/golint
+  - go get golang.org/x/lint/golint
   - go get -d ./...
 script:
   - go build -tags=gofuzz ./...


### PR DESCRIPTION
Installs golint from the canonical location to satisfy go-get checks
from tip.