### PR TITLE
Dont marshal empty LinkAttributes

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -3,7 +3,6 @@ package rtnetlink
 import (
 	"encoding"
 	"fmt"
-	"net"
 	"os"
 	"reflect"
 	"testing"
@@ -30,15 +29,6 @@ func TestConnExecute(t *testing.T) {
 			Index:  0x4030201,
 			Flags:  0x101,
 			Change: 0x4030201,
-			Attributes: LinkAttributes{
-				Address:   net.HardwareAddr(nil),
-				Broadcast: net.HardwareAddr(nil),
-				Name:      "",
-				MTU:       0x0,
-				Type:      0x0,
-				QueueDisc: "",
-				Stats:     nil,
-			},
 		},
 	}
 
@@ -147,15 +137,6 @@ func TestConnReceive(t *testing.T) {
 			Index:  0x0,
 			Flags:  0x0,
 			Change: 0x0,
-			Attributes: LinkAttributes{
-				Address:   net.HardwareAddr(nil),
-				Broadcast: net.HardwareAddr(nil),
-				Name:      "",
-				MTU:       0x0,
-				Type:      0x0,
-				QueueDisc: "",
-				Stats:     nil,
-			},
 		},
 		{
 			Family: 0x102,
@@ -163,15 +144,6 @@ func TestConnReceive(t *testing.T) {
 			Index:  0x4030201,
 			Flags:  0x102,
 			Change: 0x4030201,
-			Attributes: LinkAttributes{
-				Address:   net.HardwareAddr(nil),
-				Broadcast: net.HardwareAddr(nil),
-				Name:      "",
-				MTU:       0x0,
-				Type:      0x0,
-				QueueDisc: "",
-				Stats:     nil,
-			},
 		},
 	}
 

--- a/link.go
+++ b/link.go
@@ -39,7 +39,7 @@ type LinkMessage struct {
 	Change uint32
 
 	// Attributes List
-	Attributes LinkAttributes
+	Attributes *LinkAttributes
 }
 
 const linkMessageLength = 16
@@ -55,12 +55,16 @@ func (m *LinkMessage) MarshalBinary() ([]byte, error) {
 	nlenc.PutUint32(b[8:12], m.Flags)
 	nlenc.PutUint32(b[12:16], m.Change)
 
-	a, err := m.Attributes.MarshalBinary()
-	if err != nil {
-		return nil, err
+	if m.Attributes != nil {
+		a, err := m.Attributes.MarshalBinary()
+		if err != nil {
+			return nil, err
+		}
+
+		return append(b, a...), nil
 	}
 
-	return append(b, a...), nil
+	return b,nil
 }
 
 // UnmarshalBinary unmarshals the contents of a byte slice into a LinkMessage.
@@ -77,7 +81,7 @@ func (m *LinkMessage) UnmarshalBinary(b []byte) error {
 	m.Change = nlenc.Uint32(b[12:16])
 
 	if l > linkMessageLength {
-		m.Attributes = LinkAttributes{}
+		m.Attributes = &LinkAttributes{}
 		err := m.Attributes.UnmarshalBinary(b[16:])
 		if err != nil {
 			return err

--- a/link_test.go
+++ b/link_test.go
@@ -22,11 +22,6 @@ func TestLinkMessageMarshalBinary(t *testing.T) {
 			b: []byte{
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-				0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-				0x05, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00,
-				0x08, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00,
-				0x08, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00,
-				0x05, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00,
 			},
 		},
 		{
@@ -41,11 +36,6 @@ func TestLinkMessageMarshalBinary(t *testing.T) {
 			b: []byte{
 				0x00, 0x00, 0x01, 0x00, 0x02, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-				0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-				0x05, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00,
-				0x08, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00,
-				0x08, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00,
-				0x05, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00,
 			},
 		},
 		{
@@ -60,17 +50,12 @@ func TestLinkMessageMarshalBinary(t *testing.T) {
 			b: []byte{
 				0x00, 0x00, 0x01, 0x00, 0x02, 0x00, 0x00, 0x00,
 				0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-				0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-				0x05, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00,
-				0x08, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00,
-				0x08, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00,
-				0x05, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00,
 			},
 		},
 		{
 			name: "attributes",
 			m: &LinkMessage{
-				Attributes: LinkAttributes{
+				Attributes: &LinkAttributes{
 					Address:   []byte{0x40, 0x41, 0x42, 0x43, 0x44, 0x45},
 					Broadcast: []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
 					Name:      "lo",
@@ -92,7 +77,7 @@ func TestLinkMessageMarshalBinary(t *testing.T) {
 		{
 			name: "attributes ipip",
 			m: &LinkMessage{
-				Attributes: LinkAttributes{
+				Attributes: &LinkAttributes{
 					Address:   []byte{10, 0, 0, 1},
 					Broadcast: []byte{255, 255, 255, 255},
 					Name:      "ipip",
@@ -114,7 +99,7 @@ func TestLinkMessageMarshalBinary(t *testing.T) {
 		{
 			name: "info",
 			m: &LinkMessage{
-				Attributes: LinkAttributes{
+				Attributes: &LinkAttributes{
 					Address:   []byte{0, 0, 0, 0, 0, 0},
 					Broadcast: []byte{0, 0, 0, 0, 0, 0},
 					Name:      "lo",
@@ -149,7 +134,7 @@ func TestLinkMessageMarshalBinary(t *testing.T) {
 		{
 			name: "operational state",
 			m: &LinkMessage{
-				Attributes: LinkAttributes{
+				Attributes: &LinkAttributes{
 					Address:          []byte{10, 0, 0, 1},
 					Broadcast:        []byte{255, 255, 255, 255},
 					Name:             "ipip",
@@ -235,7 +220,7 @@ func TestLinkMessageUnmarshalBinary(t *testing.T) {
 				0x05, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00,
 			},
 			m: &LinkMessage{
-				Attributes: LinkAttributes{
+				Attributes: &LinkAttributes{
 					Address:   []byte{0, 0, 0, 0, 0, 0},
 					Broadcast: []byte{0, 0, 0, 0, 0, 0},
 				},
@@ -261,7 +246,7 @@ func TestLinkMessageUnmarshalBinary(t *testing.T) {
 				Index:  2,
 				Flags:  0,
 				Change: 0,
-				Attributes: LinkAttributes{
+				Attributes: &LinkAttributes{
 					Address:   []byte{0, 0, 0, 0, 0, 0},
 					Broadcast: []byte{0, 0, 0, 0, 0, 0},
 				},
@@ -282,7 +267,7 @@ func TestLinkMessageUnmarshalBinary(t *testing.T) {
 				0x05, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00,
 			},
 			m: &LinkMessage{
-				Attributes: LinkAttributes{
+				Attributes: &LinkAttributes{
 					Address:   []byte{0, 0, 0, 0, 0, 0},
 					Broadcast: []byte{0, 0, 0, 0, 0, 0},
 					Name:      "lo",
@@ -304,7 +289,7 @@ func TestLinkMessageUnmarshalBinary(t *testing.T) {
 				0x00, 0x00, 0x00, 0x00,
 			},
 			m: &LinkMessage{
-				Attributes: LinkAttributes{
+				Attributes: &LinkAttributes{
 					Address:   []byte{10, 0, 0, 1},
 					Broadcast: []byte{255, 255, 255, 255},
 					Name:      "ipip",
@@ -333,7 +318,7 @@ func TestLinkMessageUnmarshalBinary(t *testing.T) {
 				0x05, 0x06, 0x07, 0x08, 0x09, 0x00, 0x00, 0x00,
 			},
 			m: &LinkMessage{
-				Attributes: LinkAttributes{
+				Attributes: &LinkAttributes{
 					Address:   []byte{0, 0, 0, 0, 0, 0},
 					Broadcast: []byte{0, 0, 0, 0, 0, 0},
 					Name:      "lo",
@@ -362,7 +347,7 @@ func TestLinkMessageUnmarshalBinary(t *testing.T) {
 				0x06, 0x00, 0x00, 0x00,
 			},
 			m: &LinkMessage{
-				Attributes: LinkAttributes{
+				Attributes: &LinkAttributes{
 					Address:          []byte{10, 0, 0, 1},
 					Broadcast:        []byte{255, 255, 255, 255},
 					Name:             "ipip",


### PR DESCRIPTION
Fixes #18

When marshaling a LinkMessage the default values for LinkAttributes
causes netlink errors. By using a pointer to check if
LinkAttributes are set or not and only marshaling them if not nil
we prevent causing these errors.

Signed-off-by: Jeroen Simonetti <jeroen@simonetti.nl>