### PR TITLE
rtnl: do not drop error on Close() but leave to caller

### DIFF
--- a/rtnl/conn.go
+++ b/rtnl/conn.go
@@ -28,6 +28,6 @@ func Dial(cfg *netlink.Config) (*Conn, error) {
 }
 
 // Close the connection.
-func (c *Conn) Close() {
-	c.Conn.Close()
+func (c *Conn) Close() error {
+	return c.Conn.Close()
 }


### PR DESCRIPTION
As discussed under issue #40, it is a rather good tone to leave up to the caller to decide whether an error in Close() is a relevant factor for them.