### PR TITLE
[rtnl] Change Dial signature and add DialConfig

### DIFF
--- a/rtnl/conn.go
+++ b/rtnl/conn.go
@@ -12,14 +12,20 @@ type Conn struct {
 }
 
 // Dial the netlink socket. Establishes a new connection. The typical initialisation is:
-// 	conn, err := rtnl.Dial(nil)
+// 	conn, err := rtnl.Dial()
 //	if err != nil {
 //		log.Fatal("can't establish netlink connection: ", err)
 //	}
 //	defer conn.Close()
 //	// use conn for your calls
 //
-func Dial(cfg *netlink.Config) (*Conn, error) {
+func Dial() (*Conn, error) {
+	return DialConfig(nil)
+}
+
+// DialConfig allows you to Dial with a netlink.Config
+// to tune the connection to your liking.
+func DialConfig(cfg *netlink.Config) (*Conn, error) {
 	conn, err := rtnetlink.Dial(cfg)
 	if err != nil {
 		return nil, err

--- a/rtnl/links_live_test.go
+++ b/rtnl/links_live_test.go
@@ -5,8 +5,8 @@ package rtnl
 import (
 	"bytes"
 	"net"
-	"testing"
 	"strconv"
+	"testing"
 )
 
 const (
@@ -27,7 +27,7 @@ func hardwareAddrIsSpecified(hw net.HardwareAddr) bool {
 
 // TestLinks tests the Live function returns sane results
 func TestLiveLinks(t *testing.T) {
-	c, err := Dial(nil)
+	c, err := Dial()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +89,7 @@ func TestLiveLinks(t *testing.T) {
 				if ifindex == ieth && !hardwareAddrIsSpecified(ifc.HardwareAddr) {
 					t.Error("zero ifc.HardwareAddr, expected non-zero")
 				}
-				if ifindex == ilo && ifc.Flags&net.FlagLoopback == 0  {
+				if ifindex == ilo && ifc.Flags&net.FlagLoopback == 0 {
 					t.Error("no FlagLoopback in ifc.Flags, expected to be set")
 				}
 			})


### PR DESCRIPTION
This will change the signature to `Dial()` and removes the argument.
Most users will not want to tune their netlink connection.

A `DialConfig(netlink.Config)` function is added to allow users to tune the connection should they want to.
 
Signed-off-by: Jeroen Simonetti <jeroen@simonetti.nl>