### PR TITLE
fix: Use correct message type for Set

### DIFF
--- a/link.go
+++ b/link.go
@@ -157,9 +157,17 @@ func (l *LinkService) Get(index uint32) (LinkMessage, error) {
 }
 
 // Set sets interface attributes according to the LinkMessage information.
+//
+// ref: https://lwn.net/Articles/236919/
+// We explicitly use RTM_NEWLINK to set link attributes instead of
+// RTM_SETLINK because:
+// - using RTM_SETLINK is actually an old rtnetlink API, not supporting most
+//   attributes common today
+// - using RTM_NEWLINK is the prefered way to create AND update links
+// - RTM_NEWLINK is backward compatible to RTM_SETLINK
 func (l *LinkService) Set(req *LinkMessage) error {
 	flags := netlink.Request | netlink.Acknowledge
-	_, err := l.c.Execute(req, unix.RTM_SETLINK, flags)
+	_, err := l.c.Execute(req, unix.RTM_NEWLINK, flags)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In looking through the documentation and iproute2 code, `RTM_SETLINK`
seems to only be used in a handful of special cases, whereas `RTM_NEWLINK`
is used across the board for both new link creation as well as modification.

Example strace of setting bond mode: 
```
$ sudo strace -tt -e trace=sendmsg -v ip link set dev bond2 type bond mode 4 2>&1 
22:15:35.076608 sendmsg(3, {msg_name={sa_family=AF_NETLINK, nl_pid=0, nl_groups=00000000},
msg_namelen=12, msg_iov=[{iov_base={{len=56, type=RTM_NEWLINK, flags=NLM_F_REQUEST|NLM_F_ACK, 
seq=1573942536, pid=0}, ...
```

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>