### PR TITLE
rtnl.(Must)ParseAddr and documentation fixes

### DIFF
--- a/example_address_add_test.go
+++ b/example_address_add_test.go
@@ -16,7 +16,7 @@ func Example_addAddress() {
 	// Gather the interface Index
 	iface, _ := net.InterfaceByName("lo")
 	// Get an ip address to add to the interface
-	_, addr, _ := net.ParseCIDR("127.0.0.2/8")
+	addr, cidr, _ := net.ParseCIDR("127.0.0.2/8")
 
 	// Dial a connection to the rtnetlink socket
 	conn, err := rtnetlink.Dial(nil)
@@ -27,19 +27,19 @@ func Example_addAddress() {
 
 	// Test for the right address family for addr
 	family := unix.AF_INET6
-	to4 := addr.IP.To4()
+	to4 := cidr.IP.To4()
 	if to4 != nil {
 		family = unix.AF_INET
 	}
 	// Calculate the prefix length
-	ones, _ := addr.Mask.Size()
+	ones, _ := cidr.Mask.Size()
 
 	// Calculate the broadcast IP
 	// Only used when family is AF_INET
 	var brd net.IP
 	if to4 != nil {
 		brd = make(net.IP, len(to4))
-		binary.BigEndian.PutUint32(brd, binary.BigEndian.Uint32(to4)|^binary.BigEndian.Uint32(net.IP(addr.Mask).To4()))
+		binary.BigEndian.PutUint32(brd, binary.BigEndian.Uint32(to4)|^binary.BigEndian.Uint32(net.IP(cidr.Mask).To4()))
 	}
 
 	// Send the message using the rtnetlink.Conn
@@ -49,8 +49,8 @@ func Example_addAddress() {
 		Scope:        unix.RT_SCOPE_UNIVERSE,
 		Index:        uint32(iface.Index),
 		Attributes: rtnetlink.AddressAttributes{
-			Address:   addr.IP,
-			Local:     addr.IP,
+			Address:   addr,
+			Local:     addr,
 			Broadcast: brd,
 		},
 	})

--- a/example_address_del_test.go
+++ b/example_address_del_test.go
@@ -14,7 +14,7 @@ func Example_deleteAddress() {
 	// Gather the interface Index
 	iface, _ := net.InterfaceByName("lo")
 	// Get an ip address to delete from the interface
-	_, addr, _ := net.ParseCIDR("127.0.0.2/8")
+	addr, cidr, _ := net.ParseCIDR("127.0.0.2/8")
 
 	// Dial a connection to the rtnetlink socket
 	conn, err := rtnetlink.Dial(nil)
@@ -25,19 +25,19 @@ func Example_deleteAddress() {
 
 	// Test for the right address family for addr
 	family := unix.AF_INET6
-	to4 := addr.IP.To4()
+	to4 := cidr.IP.To4()
 	if to4 != nil {
 		family = unix.AF_INET
 	}
 	// Calculate the prefix length
-	ones, _ := addr.Mask.Size()
+	ones, _ := cidr.Mask.Size()
 
 	// Calculate the broadcast IP
 	// Only used when family is AF_INET
 	var brd net.IP
 	if to4 != nil {
 		brd = make(net.IP, len(to4))
-		binary.BigEndian.PutUint32(brd, binary.BigEndian.Uint32(to4)|^binary.BigEndian.Uint32(net.IP(addr.Mask).To4()))
+		binary.BigEndian.PutUint32(brd, binary.BigEndian.Uint32(to4)|^binary.BigEndian.Uint32(net.IP(cidr.Mask).To4()))
 	}
 
 	// Send the message using the rtnetlink.Conn
@@ -46,7 +46,7 @@ func Example_deleteAddress() {
 		PrefixLength: uint8(ones),
 		Index:        uint32(iface.Index),
 		Attributes: rtnetlink.AddressAttributes{
-			Address:   addr.IP,
+			Address:   addr,
 			Broadcast: brd,
 		},
 	})

--- a/rtnl/addr.go
+++ b/rtnl/addr.go
@@ -9,11 +9,16 @@ import (
 )
 
 // AddrAdd associates an IP-address with an interface.
+//
+//	iface, _ := net.InterfaceByName("lo")
+//	conn.AddrAdd(iface, rtnl.MustParseAddr("127.0.0.1/8"))
+//
 func (c *Conn) AddrAdd(ifc *net.Interface, addr *net.IPNet) error {
 	af, err := addrFamily(addr.IP)
 	if err != nil {
 		return err
 	}
+
 	scope := addrScope(addr.IP)
 	prefixlen, _ := addr.Mask.Size()
 	tx := &rtnetlink.AddressMessage{
@@ -35,6 +40,10 @@ func (c *Conn) AddrAdd(ifc *net.Interface, addr *net.IPNet) error {
 }
 
 // AddrDel revokes an IP-address from an interface.
+//
+//	iface, _ := net.InterfaceByName("lo")
+//	conn.AddrDel(iface, rtnl.MustParseAddr("127.0.0.1/8"))
+//
 func (c *Conn) AddrDel(ifc *net.Interface, addr *net.IPNet) error {
 	af, err := addrFamily(addr.IP)
 	if err != nil {
@@ -98,6 +107,43 @@ func (c *Conn) Addrs(ifc *net.Interface, family int) (out []*net.IPNet, err erro
 	return
 }
 
+// ParseAddr parses a CIDR string into a host address and network mask.
+// This is a convenience wrapper around net.ParseCIDR(), which surprisingly
+// returns the network address and mask instead of the host address and mask.
+func ParseAddr(s string) (*net.IPNet, error) {
+	addr, cidr, err := net.ParseCIDR(s)
+	if err != nil {
+		return nil, err
+	}
+
+	// Overwrite cidr's network address with the host address
+	// parsed from the string representation.
+	cidr.IP = addr
+
+	if isSubnetAddr(cidr) {
+		return nil, &net.AddrError{
+			Err:  "attempted to parse a subnet address into a host address",
+			Addr: cidr.IP.String()}
+	}
+
+	return cidr, nil
+}
+
+// MustParseAddr wraps ParseAddr, but panics on error.
+// Use to conveniently parse a known-valid or hardcoded
+// address into a function argument.
+//
+//	iface, _ := net.InterfaceByName("enp2s0")
+//	conn.AddrDel(iface, rtnl.MustParseAddr("10.1.1.1/24"))
+//
+func MustParseAddr(s string) *net.IPNet {
+	n, err := ParseAddr(s)
+	if err != nil {
+		panic(err)
+	}
+	return n
+}
+
 func addrFamily(ip net.IP) (int, error) {
 	if ip.To4() != nil {
 		return unix.AF_INET, nil
@@ -130,4 +176,21 @@ func broadcastAddr(ipnet *net.IPNet) net.IP {
 		out[i] = ip[i] | ^mask[i]
 	}
 	return out
+}
+
+// isSubnetAddr returns true if ipnet is a network (subnet) address.
+// It applies ipnet's subnet mask onto itself and compares the result to the
+// value of ipnet's IP field.
+func isSubnetAddr(ipnet *net.IPNet) bool {
+
+	// Addresses with /32 and /128 are always hosts.
+	if ones, bits := ipnet.Mask.Size(); ones == bits {
+		return false
+	}
+
+	if ipnet.IP.Mask(ipnet.Mask).Equal(ipnet.IP) {
+		return true
+	}
+
+	return false
 }

--- a/rtnl/addr_live_test.go
+++ b/rtnl/addr_live_test.go
@@ -94,7 +94,8 @@ func TestLiveAddrAddDel(t *testing.T) {
 	if lo == nil {
 		t.Fatal("no error but nil result")
 	}
-	testip := &net.IPNet{IP: net.IPv4(127, 0, 0, 99), Mask: net.CIDRMask(32, 32)}
+
+	testip := MustParseAddr("127.0.0.99/32")
 
 	c.AddrDel(lo, testip) // ok if fails
 

--- a/rtnl/addr_test.go
+++ b/rtnl/addr_test.go
@@ -1,0 +1,63 @@
+package rtnl
+
+import (
+	"net"
+	"testing"
+)
+
+func TestParseAddrs(t *testing.T) {
+
+	tests := []struct {
+		name  string
+		ipstr string
+		ipnet net.IPNet
+		err   string
+	}{
+		{
+			name:  "ipv6 subnet address",
+			ipstr: "ff00::/64",
+			err:   "address ff00::: attempted to parse a subnet address into a host address",
+		},
+		{
+			name:  "ipv4 subnet address",
+			ipstr: "10.0.0.0/8",
+			err:   "address 10.0.0.0: attempted to parse a subnet address into a host address",
+		},
+		{
+			name:  "ipv6 host address",
+			ipstr: "ff00::1/64",
+			ipnet: net.IPNet{
+				IP:   net.IP{0xff, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+				Mask: net.IPMask{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+			},
+		},
+		{
+			name:  "ipv4 host address",
+			ipstr: "10.0.0.1/8",
+			ipnet: net.IPNet{
+				IP:   net.IP{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xff, 0xa, 0x0, 0x0, 0x1},
+				Mask: net.IPMask{0xff, 0x0, 0x0, 0x0},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := ParseAddr(tt.ipstr)
+
+			if err != nil {
+				if want, got := tt.err, err.Error(); want != got {
+					t.Fatalf("unexpected error:\n- want: %v\n-  got: %v", want, got)
+				}
+				return
+			}
+			if tt.err != "" {
+				t.Fatalf("expected error:\n  %s\nbut got nothing.. :(", tt.err)
+			}
+
+			if want, got := tt.ipnet, res; !want.IP.Equal(got.IP) {
+				t.Fatalf("unexpected IP:\n- want: %+#v\n-  got: %+#v", want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Hi @jsimonetti, better late than never!

This addresses an issue I ran into while trying out `rtnl` and the base package. As promised, no existing behaviour or API was modified. I've added a small test suite that could use some more cases, but the code under test is quite limited.

Let me know if anything needs to be added or corrected.