### PR TITLE
rtnl - set 'host' scope when adding loopback addresses

### DIFF
--- a/rtnl/addr.go
+++ b/rtnl/addr.go
@@ -158,6 +158,9 @@ func addrScope(ip net.IP) int {
 	if ip.IsGlobalUnicast() {
 		return unix.RT_SCOPE_UNIVERSE
 	}
+	if ip.IsLoopback() {
+		return unix.RT_SCOPE_HOST
+	}
 	return unix.RT_SCOPE_LINK
 }
 


### PR DESCRIPTION
@jsimonetti Turns out host scope needs to be set explicitly when adding loopback addresses other than `127.0.0.1`. (strace shows `ifa_scope=RT_SCOPE_HOST,` when using `ip a add 127.0.1.1/8 dev lo`) 

`127.0.0.1` in particular might be hardcoded in the kernel, because sending `RT_SCOPE_LINK` works fine for that one. For anything else that starts with `127`, `RT_SCOPE_HOST` seems to be required.