### PR TITLE
rtnetlink: expose Conn.SetReadDeadline

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -2,6 +2,7 @@ package rtnetlink
 
 import (
 	"encoding"
+	"time"
 
 	"github.com/jsimonetti/rtnetlink/internal/unix"
 
@@ -26,6 +27,7 @@ type conn interface {
 	Send(m netlink.Message) (netlink.Message, error)
 	Receive() ([]netlink.Message, error)
 	Execute(m netlink.Message) ([]netlink.Message, error)
+	SetReadDeadline(t time.Time) error
 }
 
 // Dial dials a route netlink connection.  Config specifies optional
@@ -58,6 +60,14 @@ func newConn(c conn) *Conn {
 // Close closes the connection.
 func (c *Conn) Close() error {
 	return c.c.Close()
+}
+
+// SetReadDeadline sets the read deadline associated with the connection.
+//
+// Deadline functionality is only supported on Go 1.12+. Calling this function
+// on older versions of Go will result in an error.
+func (c *Conn) SetReadDeadline(t time.Time) error {
+	return c.c.SetReadDeadline(t)
 }
 
 // Send sends a single Message to netlink, wrapping it in a netlink.Message

--- a/conn_test.go
+++ b/conn_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/mdlayher/netlink"
 	"golang.org/x/sys/unix"
@@ -210,6 +211,7 @@ func (c *noopConn) Close() error                                         { retur
 func (c *noopConn) Send(_ netlink.Message) (netlink.Message, error)      { return netlink.Message{}, nil }
 func (c *noopConn) Receive() ([]netlink.Message, error)                  { return nil, nil }
 func (c *noopConn) Execute(m netlink.Message) ([]netlink.Message, error) { return nil, nil }
+func (c *noopConn) SetReadDeadline(t time.Time) error                    { return nil }
 
 func mustMarshal(m encoding.BinaryMarshaler) []byte {
 	b, err := m.MarshalBinary()


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

This is necessary to enable unblocking a receive operation by setting a past deadline.