### PR TITLE
Add a filter by kind to the link list command

### DIFF
--- a/link.go
+++ b/link.go
@@ -178,8 +178,8 @@ func (l *LinkService) Set(req *LinkMessage) error {
 func (l *LinkService) list(kind string) ([]LinkMessage, error) {
 	req := &LinkMessage{}
 	if kind != "" {
-		req.Attributes = &rtnetlink.LinkAttributes{
-			Info: &rtnetlink.LinkInfo{Kind: kind},
+		req.Attributes = &LinkAttributes{
+			Info: &LinkInfo{Kind: kind},
 		}
 	}
 

--- a/link.go
+++ b/link.go
@@ -175,9 +175,13 @@ func (l *LinkService) Set(req *LinkMessage) error {
 	return nil
 }
 
-// List retrieves all interfaces.
-func (l *LinkService) List() ([]LinkMessage, error) {
+func (l *LinkService) list(kind string) ([]LinkMessage, error) {
 	req := &LinkMessage{}
+	if kind != "" {
+		req.Attributes = &rtnetlink.LinkAttributes{
+			Info: &rtnetlink.LinkInfo{Kind: kind},
+		}
+	}
 
 	flags := netlink.Request | netlink.Dump
 	msgs, err := l.c.Execute(req, unix.RTM_GETLINK, flags)
@@ -192,6 +196,16 @@ func (l *LinkService) List() ([]LinkMessage, error) {
 	}
 
 	return links, nil
+}
+
+// ListByKind retrieves all interfaces of a specific kind.
+func (l *LinkService) ListByKind(kind string) ([]LinkMessage, error) {
+	return l.list(kind)
+}
+
+// List retrieves all interfaces.
+func (l *LinkService) List() ([]LinkMessage, error) {
+	return l.list("")
 }
 
 // LinkAttributes contains all attributes for an interface.


### PR DESCRIPTION
Hey,
In my project I needed to use the`link list` command to get network interfaces by a specific kind. 
With `iproute2` this is supported via `ip link list type <TYPE>`. 
This addition adds this capability via the `ListByKind` function, I left the existent `list` function intact and just wrapped my filtering around it. 

Let me know if there is anything else needed, thanks!