### PR TITLE
rtnetlink: add RouteMetrics nested attributes within RouteAttributes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/jsimonetti/rtnetlink
 go 1.12
 
 require (
+	github.com/google/go-cmp v0.5.2
 	github.com/mdlayher/netlink v1.1.0
 	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/jsimonetti/rtnetlink v0.0.0-20190606172950-9527aa82566a/go.mod h1:Oz+70psSo5OFh8DBl0Zv2ACw7Esh6pPUphlvZG9x7uw=
 github.com/jsimonetti/rtnetlink v0.0.0-20200117123717-f846d4f6c1f4/go.mod h1:WGuG/smIU4J/54PblvSbh+xvCZmpJnFgr3ds6Z55XMQ=
 github.com/mdlayher/netlink v0.0.0-20190409211403-11939a169225/go.mod h1:eQB3mZE4aiYnlUsyGGCOpPETfdQq4Jhsgf1fk3cwQaA=

--- a/internal/unix/types_linux.go
+++ b/internal/unix/types_linux.go
@@ -72,6 +72,11 @@ const (
 	RTA_TABLE            = linux.RTA_TABLE
 	RTA_MARK             = linux.RTA_MARK
 	RTA_EXPIRES          = linux.RTA_EXPIRES
+	RTA_METRICS          = linux.RTA_METRICS
+	RTAX_ADVMSS          = linux.RTAX_ADVMSS
+	RTAX_FEATURES        = linux.RTAX_FEATURES
+	RTAX_INITCWND        = linux.RTAX_INITCWND
+	RTAX_MTU             = linux.RTAX_MTU
 	NTF_PROXY            = linux.NTF_PROXY
 	RTN_UNICAST          = linux.RTN_UNICAST
 	RT_TABLE_MAIN        = linux.RT_TABLE_MAIN

--- a/internal/unix/types_other.go
+++ b/internal/unix/types_other.go
@@ -68,6 +68,11 @@ const (
 	RTA_TABLE            = 0xf
 	RTA_MARK             = 0x10
 	RTA_EXPIRES          = 0x17
+	RTA_METRICS          = 0x8
+	RTAX_ADVMSS          = 0x8
+	RTAX_FEATURES        = 0xc
+	RTAX_INITCWND        = 0xb
+	RTAX_MTU             = 0x2
 	NTF_PROXY            = 0x8
 	RTN_UNICAST          = 0x1
 	RT_TABLE_MAIN        = 0xfe


### PR DESCRIPTION
Signed-off-by: Matt Layher <mlayher@fastly.com>

I've added a few new attributes to the route message type and have introduced go-cmp in the route message tests for cleaner and easier to read diff output than what reflect can provide. Thanks again!

I'll have another change to add more attributes early next week.