### PR TITLE
[rtnl] support functional args for routes

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,7 @@ github.com/mdlayher/netlink v0.0.0-20190409211403-11939a169225/go.mod h1:eQB3mZE
 github.com/mdlayher/netlink v1.0.0/go.mod h1:KxeJAFOFLG6AjpyDkQ/iIhxygIUKD+vcwqcnu43w/+M=
 github.com/mdlayher/netlink v1.1.0 h1:mpdLgm+brq10nI9zM1BpX1kpDbh3NLl3RSnVq6ZSkfg=
 github.com/mdlayher/netlink v1.1.0/go.mod h1:H4WCitaheIsdF9yOYu8CFmCgQthAPIWZmcKp9uZHgmY=
+github.com/mdlayher/netlink v1.1.1 h1:VqG+Voq9V4uZ+04vjIrcSCWDpf91B1xxbP4QBUmUJE8=
 github.com/mdlayher/netlink v1.1.1/go.mod h1:WTYpFb/WTvlRJAyKhZL5/uy69TDDpHHu2VZmb2XgV7o=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -20,6 +21,7 @@ golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20191007182048-72f939374954/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20201010224723-4f7140c49acb h1:mUVeFHoDKis5nxCAzoAi7E8Ghb86EXh/RK6wtvJIqRY=
 golang.org/x/net v0.0.0-20201010224723-4f7140c49acb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -30,6 +32,7 @@ golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 h1:LfCXLvNmTYH9kEmVgqbnsWfruoXZIrh4YBgqVHtDvw0=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634 h1:bNEHhJCnrwMKNMmOx3yAynp5vs5/gRy+XWFtZFu7NBM=
 golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/rtnl/route_options.go
+++ b/rtnl/route_options.go
@@ -1,0 +1,47 @@
+package rtnl
+
+import (
+	"net"
+
+	"github.com/jsimonetti/rtnetlink"
+)
+
+// RouteOptions is the functional options struct
+type RouteOptions struct {
+	Src   *net.IPNet
+	Attrs rtnetlink.RouteAttributes
+}
+
+// RouteOption is the functional options func
+type RouteOption func(*RouteOptions)
+
+// DefaultRouteOptions defines the default route options.
+func DefaultRouteOptions(ifc *net.Interface, dst net.IPNet, gw net.IP) *RouteOptions {
+	ro := &RouteOptions{
+		Src: nil,
+		Attrs: rtnetlink.RouteAttributes{
+			Dst:      dst.IP,
+			OutIface: uint32(ifc.Index),
+		},
+	}
+
+	if gw != nil {
+		ro.Attrs.Gateway = gw
+	}
+
+	return ro
+}
+
+// WithRouteSrc sets the src address.
+func WithRouteSrc(src *net.IPNet) RouteOption {
+	return func(opts *RouteOptions) {
+		opts.Src = src
+	}
+}
+
+// WithRouteAttrs sets the attributes.
+func WithRouteAttrs(attrs rtnetlink.RouteAttributes) RouteOption {
+	return func(opts *RouteOptions) {
+		opts.Attrs = attrs
+	}
+}


### PR DESCRIPTION
This PR will add the ability to use functional args for route
add/replace with rtnl. Currently, two functions are supported,
`WithRouteSrc` and `WithRouteAttrs`. This allows the consolidation of
the route methods, as well as adding the ability to BYO-Attributes for a
given route. This layout can of course be extended to add other
route-specific args, as well as a starting point for options and args for other parts of the
rtnl package as time goes on.

Note that this removes the `RouteAddSrc` and `RouteReplaceSrc`
functions.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>