### PR TITLE
rtnetlink: remove outdated Go version warning on Conn.SetReadDeadline

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -63,9 +63,6 @@ func (c *Conn) Close() error {
 }
 
 // SetReadDeadline sets the read deadline associated with the connection.
-//
-// Deadline functionality is only supported on Go 1.12+. Calling this function
-// on older versions of Go will result in an error.
 func (c *Conn) SetReadDeadline(t time.Time) error {
 	return c.c.SetReadDeadline(t)
 }


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

We're on netlink v1.4.1 and already dropped support for old Go as of v1.2.0 there.