### PR TITLE
rtnetlink: expose Conn.SetOption from underlying netlink.Conn

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -27,6 +27,7 @@ type conn interface {
 	Send(m netlink.Message) (netlink.Message, error)
 	Receive() ([]netlink.Message, error)
 	Execute(m netlink.Message) ([]netlink.Message, error)
+	SetOption(option netlink.ConnOption, enable bool) error
 	SetReadDeadline(t time.Time) error
 }
 
@@ -60,6 +61,11 @@ func newConn(c conn) *Conn {
 // Close closes the connection.
 func (c *Conn) Close() error {
 	return c.c.Close()
+}
+
+// SetOption enables or disables a netlink socket option for the Conn.
+func (c *Conn) SetOption(option netlink.ConnOption, enable bool) error {
+	return c.c.SetOption(option, enable)
 }
 
 // SetReadDeadline sets the read deadline associated with the connection.

--- a/conn_test.go
+++ b/conn_test.go
@@ -211,6 +211,7 @@ func (c *noopConn) Close() error                                         { retur
 func (c *noopConn) Send(_ netlink.Message) (netlink.Message, error)      { return netlink.Message{}, nil }
 func (c *noopConn) Receive() ([]netlink.Message, error)                  { return nil, nil }
 func (c *noopConn) Execute(m netlink.Message) ([]netlink.Message, error) { return nil, nil }
+func (c *noopConn) SetOption(_ netlink.ConnOption, _ bool) error         { return nil }
 func (c *noopConn) SetReadDeadline(t time.Time) error                    { return nil }
 
 func mustMarshal(m encoding.BinaryMarshaler) []byte {


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

Updates #121.