### PR TITLE
rtnetlink: make AddressMessage.Attributes optional via pointer

### DIFF
--- a/address_test.go
+++ b/address_test.go
@@ -25,9 +25,6 @@ func TestAddressMessageMarshalBinary(t *testing.T) {
 			m:    &AddressMessage{},
 			b: []byte{
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-				0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-				0x04, 0x00, 0x01, 0x00, 0x08, 0x00, 0x08, 0x00,
-				0x00, 0x00, 0x00, 0x00,
 			},
 		},
 		{
@@ -41,15 +38,12 @@ func TestAddressMessageMarshalBinary(t *testing.T) {
 			},
 			b: []byte{
 				0x02, 0x08, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
-				0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-				0x04, 0x00, 0x01, 0x00, 0x08, 0x00, 0x08, 0x00,
-				0x00, 0x00, 0x00, 0x00,
 			},
 		},
 		{
 			name: "attributes",
 			m: &AddressMessage{
-				Attributes: AddressAttributes{
+				Attributes: &AddressAttributes{
 					Address:   []byte{0, 0, 0, 0, 0, 0},
 					Broadcast: []byte{0, 0, 0, 0, 0, 0},
 					Label:     "lo",
@@ -65,9 +59,9 @@ func TestAddressMessageMarshalBinary(t *testing.T) {
 			},
 		},
 		{
-			name: "no broadcast ",
+			name: "no broadcast",
 			m: &AddressMessage{
-				Attributes: AddressAttributes{
+				Attributes: &AddressAttributes{
 					Address: []byte{0, 0, 0, 0, 0, 0},
 					Label:   "lo",
 				},
@@ -150,7 +144,7 @@ func TestAddressMessageUnmarshalBinary(t *testing.T) {
 				Flags:        0xfe,
 				Scope:        1,
 				Index:        1,
-				Attributes: AddressAttributes{
+				Attributes: &AddressAttributes{
 					Address:   net.IP{0x7f, 0x0, 0x0, 0x1},
 					Local:     net.IP{0x7f, 0x0, 0x0, 0x1},
 					Label:     "lo",

--- a/example_address_add_test.go
+++ b/example_address_add_test.go
@@ -48,7 +48,7 @@ func Example_addAddress() {
 		PrefixLength: uint8(ones),
 		Scope:        unix.RT_SCOPE_UNIVERSE,
 		Index:        uint32(iface.Index),
-		Attributes: rtnetlink.AddressAttributes{
+		Attributes: &rtnetlink.AddressAttributes{
 			Address:   addr,
 			Local:     addr,
 			Broadcast: brd,

--- a/example_address_del_test.go
+++ b/example_address_del_test.go
@@ -45,7 +45,7 @@ func Example_deleteAddress() {
 		Family:       uint8(family),
 		PrefixLength: uint8(ones),
 		Index:        uint32(iface.Index),
-		Attributes: rtnetlink.AddressAttributes{
+		Attributes: &rtnetlink.AddressAttributes{
 			Address:   addr,
 			Broadcast: brd,
 		},

--- a/rtnl/addr.go
+++ b/rtnl/addr.go
@@ -26,7 +26,7 @@ func (c *Conn) AddrAdd(ifc *net.Interface, addr *net.IPNet) error {
 		PrefixLength: uint8(prefixlen),
 		Scope:        uint8(scope),
 		Index:        uint32(ifc.Index),
-		Attributes: rtnetlink.AddressAttributes{
+		Attributes: &rtnetlink.AddressAttributes{
 			Address: addr.IP,
 			Local:   addr.IP,
 		},
@@ -61,7 +61,7 @@ func (c *Conn) AddrDel(ifc *net.Interface, addr *net.IPNet) error {
 				Family:       uint8(af),
 				PrefixLength: uint8(prefixlen),
 				Index:        uint32(ifc.Index),
-				Attributes: rtnetlink.AddressAttributes{
+				Attributes: &rtnetlink.AddressAttributes{
 					Address: addr.IP,
 				},
 			}


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

I need the ability to completely omit the address attributes structure when filtering addresses by interface with strict checking enabled. Currently the marshaling code reports an error due to the empty attributes:

```
netlink receive: invalid argument, offset: 0, message: "Unknown attribute type"
```

Although this is a minor breaking change, we haven't tagged a stable release and it seems necessary to fix this now in order to enable better flexibility in tandem with strict checking enabled.

Updates #121.