### PR TITLE
rtnetlink: Go 1.17 build tags, fix example build tags

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package rtnetlink

--- a/example_address_add_test.go
+++ b/example_address_add_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package rtnetlink_test

--- a/example_address_del_test.go
+++ b/example_address_del_test.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 package rtnetlink_test
 
 import (

--- a/example_address_list_test.go
+++ b/example_address_list_test.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 package rtnetlink_test
 
 import (

--- a/example_link_setup_test.go
+++ b/example_link_setup_test.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 package rtnetlink_test
 
 import (

--- a/example_neigh_list_test.go
+++ b/example_neigh_list_test.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 package rtnetlink_test
 
 import (

--- a/example_route_add_test.go
+++ b/example_route_add_test.go
@@ -1,4 +1,5 @@
-// +build
+//go:build linux
+// +build linux
 
 package rtnetlink_test
 

--- a/fuzz.go
+++ b/fuzz.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package rtnetlink

--- a/internal/unix/types_linux.go
+++ b/internal/unix/types_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package unix

--- a/internal/unix/types_other.go
+++ b/internal/unix/types_other.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package unix

--- a/link_live_test.go
+++ b/link_live_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package rtnetlink

--- a/rtnl/addr_live_test.go
+++ b/rtnl/addr_live_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package rtnl

--- a/rtnl/links_live_test.go
+++ b/rtnl/links_live_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package rtnl

--- a/rtnl/neigh_live_test.go
+++ b/rtnl/neigh_live_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package rtnl

--- a/rtnl/route_live_test.go
+++ b/rtnl/route_live_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package rtnl


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

Anything that imports x/sys needs build tags.