### PR TITLE
rtnetlink: support for RTA_PREF

### DIFF
--- a/internal/unix/types_linux.go
+++ b/internal/unix/types_linux.go
@@ -94,6 +94,7 @@ const (
 	RTA_EXPIRES                 = linux.RTA_EXPIRES
 	RTA_METRICS                 = linux.RTA_METRICS
 	RTA_MULTIPATH               = linux.RTA_MULTIPATH
+	RTA_PREF                    = linux.RTA_PREF
 	RTAX_ADVMSS                 = linux.RTAX_ADVMSS
 	RTAX_FEATURES               = linux.RTAX_FEATURES
 	RTAX_INITCWND               = linux.RTAX_INITCWND

--- a/internal/unix/types_other.go
+++ b/internal/unix/types_other.go
@@ -90,6 +90,7 @@ const (
 	RTA_EXPIRES                 = 0x17
 	RTA_METRICS                 = 0x8
 	RTA_MULTIPATH               = 0x9
+	RTA_PREF                    = 0x14
 	RTAX_ADVMSS                 = 0x8
 	RTAX_FEATURES               = 0xc
 	RTAX_INITCWND               = 0xb

--- a/route.go
+++ b/route.go
@@ -162,6 +162,7 @@ type RouteAttributes struct {
 	Priority  uint32
 	Table     uint32
 	Mark      uint32
+	Pref      *uint8
 	Expires   *uint32
 	Metrics   *RouteMetrics
 	Multipath []NextHop
@@ -194,6 +195,9 @@ func (a *RouteAttributes) decode(ad *netlink.AttributeDecoder) error {
 			ad.Nested(a.Metrics.decode)
 		case unix.RTA_MULTIPATH:
 			ad.Do(a.parseMultipath)
+		case unix.RTA_PREF:
+			pref := ad.Uint8()
+			a.Pref = &pref
 		}
 	}
 
@@ -227,6 +231,10 @@ func (a *RouteAttributes) encode(ae *netlink.AttributeEncoder) error {
 
 	if a.Mark != 0 {
 		ae.Uint32(unix.RTA_MARK, a.Mark)
+	}
+
+	if a.Pref != nil {
+		ae.Uint8(unix.RTA_PREF, *a.Pref)
 	}
 
 	if a.Expires != nil {

--- a/route_test.go
+++ b/route_test.go
@@ -13,7 +13,11 @@ import (
 func TestRouteMessageMarshalUnmarshalBinary(t *testing.T) {
 	skipBigEndian(t)
 
-	timeout := uint32(255)
+	var (
+		timeout = uint32(255)
+		pref    = uint8(1)
+	)
+
 	tests := []struct {
 		name string
 		m    *RouteMessage
@@ -56,6 +60,7 @@ func TestRouteMessageMarshalUnmarshalBinary(t *testing.T) {
 					Priority: 1,
 					Table:    2,
 					Mark:     3,
+					Pref:     &pref,
 					Expires:  &timeout,
 					Metrics: &RouteMetrics{
 						AdvMSS:   1,
@@ -127,6 +132,9 @@ func TestRouteMessageMarshalUnmarshalBinary(t *testing.T) {
 				// Mark
 				0x08, 0x00, 0x10, 0x00,
 				0x03, 0x00, 0x00, 0x00,
+				// Pref
+				0x05, 0x00, 0x14, 0x00,
+				0x01, 0x00, 0x00, 0x00,
 				// Expires
 				0x08, 0x00, 0x17, 0x00,
 				0xff, 0x00, 0x00, 0x00,


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

Another optional one because the zero value "medium" pref cannot be set in strict check dump requests.