### PR TITLE
Fix invalid LinkMessage family

### DIFF
--- a/example_link_setdown_test.go
+++ b/example_link_setdown_test.go
@@ -33,7 +33,7 @@ func Example_setLinkDown() {
 
 	// Set the interface operationally Down
 	err = conn.Link.Set(&rtnetlink.LinkMessage{
-		Family: msg.Family,
+		Family: 0x0,
 		Type:   msg.Type,
 		Index:  uint32(iface.Index),
 		Flags:  0x0,

--- a/example_link_sethwaddr_test.go
+++ b/example_link_sethwaddr_test.go
@@ -29,7 +29,7 @@ func Example_setLinkHWAddr() {
 
 	// Set the hw address of the interfaces
 	err = conn.Link.Set(&rtnetlink.LinkMessage{
-		Family: msg.Family,
+		Family: 0x0,
 		Type:   msg.Type,
 		Index:  uint32(iface.Index),
 		Flags:  msg.Flags,

--- a/example_link_setup_test.go
+++ b/example_link_setup_test.go
@@ -37,7 +37,7 @@ func Example_setLinkUp() {
 
 	// Set the interface operationally UP
 	err = conn.Link.Set(&rtnetlink.LinkMessage{
-		Family: msg.Family,
+		Family: unix.AF_UNSPEC,
 		Type:   msg.Type,
 		Index:  uint32(iface.Index),
 		Flags:  unix.IFF_UP,

--- a/rtnl/link.go
+++ b/rtnl/link.go
@@ -92,7 +92,7 @@ func (c *Conn) LinkUp(ifc *net.Interface) error {
 		return err
 	}
 	tx := &rtnetlink.LinkMessage{
-		Family: rx.Family,
+		Family: unix.AF_UNSPEC,
 		Type:   rx.Type,
 		Index:  uint32(ifc.Index),
 		Flags:  unix.IFF_UP,
@@ -108,7 +108,7 @@ func (c *Conn) LinkDown(ifc *net.Interface) error {
 		return err
 	}
 	tx := &rtnetlink.LinkMessage{
-		Family: rx.Family,
+		Family: unix.AF_UNSPEC,
 		Type:   rx.Type,
 		Index:  uint32(ifc.Index),
 		Flags:  0,


### PR DESCRIPTION
Currently LinkUp/LinkDown fails to work on some network cards with EINVAL, as `rx.Family` is not always `AF_UNSPEC`. Passing AF_UNSPEC explicitly seems to be safe, it's also used by [vishvananda/netlink](https://github.com/vishvananda/netlink/blob/7b913bc23ecb7f817bebf8ac50fe1ef1b9d36799/link_linux.go#L376-L413).

Let's make this comment true :smile::

https://github.com/jsimonetti/rtnetlink/blob/896a1067bb59d587f6588a00916d7b490398d173/link.go#L24-L26