### PR TITLE
Allow empty neighbor LLAddress

### DIFF
--- a/neigh.go
+++ b/neigh.go
@@ -194,6 +194,10 @@ func (a *NeighAttributes) decode(ad *netlink.AttributeDecoder) error {
 			// Allow IEEE 802 MAC-48, EUI-48, EUI-64, or 20-octet
 			// IP over InfiniBand link-layer addresses
 			l := len(ad.Bytes())
+			if l == 0 {
+				// Ignore empty addresses.
+				continue
+			}
 			if l != 6 && l != 8 && l != 20 {
 				return errInvalidNeighMessageAttr
 			}


### PR DESCRIPTION
The kernel sometimes returns empty LLAddress in NeighAttributes. Allow this to be returned as a nil address.

Fixes: https://github.com/jsimonetti/rtnetlink/issues/199