### PR TITLE
Update minimum Go version

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -17,9 +17,9 @@
 // netlink traffic inside the kernel. Be aware that this might be overwhelming on a system
 // with a lot of netlink traffic.
 //
-//  # modprobe nlmon
-//  # ip link add type nlmon
-//  # ip link set nlmon0 up
+//	# modprobe nlmon
+//	# ip link add type nlmon
+//	# ip link set nlmon0 up
 //
 // At this point use wireshark or tcpdump on the nlmon0 interface to view all netlink traffic.
 //

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jsimonetti/rtnetlink
 
-go 1.18
+go 1.20
 
 require (
 	github.com/cilium/ebpf v0.12.3

--- a/link.go
+++ b/link.go
@@ -163,10 +163,10 @@ func (l *LinkService) Get(index uint32) (LinkMessage, error) {
 // ref: https://lwn.net/Articles/236919/
 // We explicitly use RTM_NEWLINK to set link attributes instead of
 // RTM_SETLINK because:
-// - using RTM_SETLINK is actually an old rtnetlink API, not supporting most
-//   attributes common today
-// - using RTM_NEWLINK is the prefered way to create AND update links
-// - RTM_NEWLINK is backward compatible to RTM_SETLINK
+//   - using RTM_SETLINK is actually an old rtnetlink API, not supporting most
+//     attributes common today
+//   - using RTM_NEWLINK is the prefered way to create AND update links
+//   - RTM_NEWLINK is backward compatible to RTM_SETLINK
 func (l *LinkService) Set(req *LinkMessage) error {
 	flags := netlink.Request | netlink.Acknowledge
 	_, err := l.c.Execute(req, unix.RTM_NEWLINK, flags)


### PR DESCRIPTION
Go mod version (1.18) is older than depencies (1.20)
- github.com/cilium/ebpf
- github.com/mdlayher/socket

Update `go fmt` for latest Go release.