### PR TITLE
Fix Go mod path

### DIFF
--- a/address.go
+++ b/address.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/jsimonetti/rtnetlink/internal/unix"
+	"github.com/jsimonetti/rtnetlink/v2/internal/unix"
 
 	"github.com/mdlayher/netlink"
 )

--- a/address_test.go
+++ b/address_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/jsimonetti/rtnetlink/internal/unix"
+	"github.com/jsimonetti/rtnetlink/v2/internal/unix"
 	"github.com/mdlayher/netlink/nlenc"
 )
 

--- a/conn.go
+++ b/conn.go
@@ -4,7 +4,7 @@ import (
 	"encoding"
 	"time"
 
-	"github.com/jsimonetti/rtnetlink/internal/unix"
+	"github.com/jsimonetti/rtnetlink/v2/internal/unix"
 
 	"github.com/mdlayher/netlink"
 )

--- a/driver/bond.go
+++ b/driver/bond.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/jsimonetti/rtnetlink"
-	"github.com/jsimonetti/rtnetlink/internal/unix"
+	"github.com/jsimonetti/rtnetlink/v2"
+	"github.com/jsimonetti/rtnetlink/v2/internal/unix"
 	"github.com/mdlayher/netlink"
 )
 

--- a/driver/bond_live_test.go
+++ b/driver/bond_live_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/jsimonetti/rtnetlink"
+	"github.com/jsimonetti/rtnetlink/v2"
 	"github.com/mdlayher/netlink"
 )
 

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -1,7 +1,7 @@
 package driver
 
 import (
-	"github.com/jsimonetti/rtnetlink"
+	"github.com/jsimonetti/rtnetlink/v2"
 )
 
 // init registers predefined drivers with the rtnetlink package.

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -9,7 +9,7 @@ import (
 	"os/exec"
 	"testing"
 
-	"github.com/jsimonetti/rtnetlink"
+	"github.com/jsimonetti/rtnetlink/v2"
 	"golang.org/x/sys/unix"
 )
 

--- a/driver/netkit.go
+++ b/driver/netkit.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/jsimonetti/rtnetlink"
-	"github.com/jsimonetti/rtnetlink/internal/unix"
+	"github.com/jsimonetti/rtnetlink/v2"
+	"github.com/jsimonetti/rtnetlink/v2/internal/unix"
 	"github.com/mdlayher/netlink"
 )
 

--- a/driver/netkit_live_test.go
+++ b/driver/netkit_live_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/jsimonetti/rtnetlink"
+	"github.com/jsimonetti/rtnetlink/v2"
 	"github.com/mdlayher/netlink"
 )
 

--- a/driver/veth.go
+++ b/driver/veth.go
@@ -3,7 +3,7 @@ package driver
 import (
 	"fmt"
 
-	"github.com/jsimonetti/rtnetlink"
+	"github.com/jsimonetti/rtnetlink/v2"
 	"github.com/mdlayher/netlink"
 )
 

--- a/driver/veth_live_test.go
+++ b/driver/veth_live_test.go
@@ -6,7 +6,7 @@ package driver
 import (
 	"testing"
 
-	"github.com/jsimonetti/rtnetlink"
+	"github.com/jsimonetti/rtnetlink/v2"
 	"github.com/mdlayher/netlink"
 )
 

--- a/example_address_add_test.go
+++ b/example_address_add_test.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"net"
 
-	"github.com/jsimonetti/rtnetlink"
+	"github.com/jsimonetti/rtnetlink/v2"
 	"golang.org/x/sys/unix"
 )
 

--- a/example_address_del_test.go
+++ b/example_address_del_test.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"net"
 
-	"github.com/jsimonetti/rtnetlink"
+	"github.com/jsimonetti/rtnetlink/v2"
 	"golang.org/x/sys/unix"
 )
 

--- a/example_address_list_test.go
+++ b/example_address_list_test.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"net"
 
-	"github.com/jsimonetti/rtnetlink"
+	"github.com/jsimonetti/rtnetlink/v2"
 	"golang.org/x/sys/unix"
 )
 

--- a/example_link_list_test.go
+++ b/example_link_list_test.go
@@ -3,7 +3,7 @@ package rtnetlink_test
 import (
 	"log"
 
-	"github.com/jsimonetti/rtnetlink"
+	"github.com/jsimonetti/rtnetlink/v2"
 )
 
 // List all interfaces

--- a/example_link_setdown_test.go
+++ b/example_link_setdown_test.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"net"
 
-	"github.com/jsimonetti/rtnetlink"
+	"github.com/jsimonetti/rtnetlink/v2"
 )
 
 // Set the operational state an interface to Down

--- a/example_link_sethwaddr_test.go
+++ b/example_link_sethwaddr_test.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"net"
 
-	"github.com/jsimonetti/rtnetlink"
+	"github.com/jsimonetti/rtnetlink/v2"
 )
 
 // Set the hw address of an interface

--- a/example_link_setup_test.go
+++ b/example_link_setup_test.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"net"
 
-	"github.com/jsimonetti/rtnetlink"
+	"github.com/jsimonetti/rtnetlink/v2"
 	"golang.org/x/sys/unix"
 )
 

--- a/example_neigh_list_test.go
+++ b/example_neigh_list_test.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"net"
 
-	"github.com/jsimonetti/rtnetlink"
+	"github.com/jsimonetti/rtnetlink/v2"
 	"golang.org/x/sys/unix"
 )
 

--- a/example_route_add_test.go
+++ b/example_route_add_test.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"net"
 
-	"github.com/jsimonetti/rtnetlink"
+	"github.com/jsimonetti/rtnetlink/v2"
 	"golang.org/x/sys/unix"
 )
 

--- a/example_rule_list_test.go
+++ b/example_rule_list_test.go
@@ -3,7 +3,7 @@ package rtnetlink_test
 import (
 	"log"
 
-	"github.com/jsimonetti/rtnetlink"
+	"github.com/jsimonetti/rtnetlink/v2"
 )
 
 // List all rules

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jsimonetti/rtnetlink
+module github.com/jsimonetti/rtnetlink/v2
 
 go 1.20
 

--- a/link.go
+++ b/link.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/jsimonetti/rtnetlink/internal/unix"
+	"github.com/jsimonetti/rtnetlink/v2/internal/unix"
 
 	"github.com/mdlayher/netlink"
 )

--- a/neigh.go
+++ b/neigh.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/jsimonetti/rtnetlink/internal/unix"
+	"github.com/jsimonetti/rtnetlink/v2/internal/unix"
 
 	"github.com/mdlayher/netlink"
 )

--- a/neigh_test.go
+++ b/neigh_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/jsimonetti/rtnetlink/internal/unix"
+	"github.com/jsimonetti/rtnetlink/v2/internal/unix"
 )
 
 // Tests will only pass on little endian machines

--- a/netns.go
+++ b/netns.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/jsimonetti/rtnetlink/internal/unix"
+	"github.com/jsimonetti/rtnetlink/v2/internal/unix"
 )
 
 // NetNS represents a Linux network namespace

--- a/route.go
+++ b/route.go
@@ -7,7 +7,7 @@ import (
 	"net"
 	"unsafe"
 
-	"github.com/jsimonetti/rtnetlink/internal/unix"
+	"github.com/jsimonetti/rtnetlink/v2/internal/unix"
 
 	"github.com/mdlayher/netlink"
 )

--- a/route_test.go
+++ b/route_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/jsimonetti/rtnetlink/internal/unix"
+	"github.com/jsimonetti/rtnetlink/v2/internal/unix"
 )
 
 // Tests will only pass on little endian machines

--- a/rtnl/addr.go
+++ b/rtnl/addr.go
@@ -3,9 +3,9 @@ package rtnl
 import (
 	"net"
 
-	"github.com/jsimonetti/rtnetlink/internal/unix"
+	"github.com/jsimonetti/rtnetlink/v2/internal/unix"
 
-	"github.com/jsimonetti/rtnetlink"
+	"github.com/jsimonetti/rtnetlink/v2"
 )
 
 // AddrAdd associates an IP-address with an interface.

--- a/rtnl/conn.go
+++ b/rtnl/conn.go
@@ -2,7 +2,7 @@
 package rtnl
 
 import (
-	"github.com/jsimonetti/rtnetlink"
+	"github.com/jsimonetti/rtnetlink/v2"
 	"github.com/mdlayher/netlink"
 )
 

--- a/rtnl/link.go
+++ b/rtnl/link.go
@@ -3,9 +3,9 @@ package rtnl
 import (
 	"net"
 
-	"github.com/jsimonetti/rtnetlink/internal/unix"
+	"github.com/jsimonetti/rtnetlink/v2/internal/unix"
 
-	"github.com/jsimonetti/rtnetlink"
+	"github.com/jsimonetti/rtnetlink/v2"
 )
 
 // Links return the list of interfaces available on the system.

--- a/rtnl/neigh.go
+++ b/rtnl/neigh.go
@@ -3,7 +3,7 @@ package rtnl
 import (
 	"net"
 
-	"github.com/jsimonetti/rtnetlink"
+	"github.com/jsimonetti/rtnetlink/v2"
 )
 
 // Neigh represents a neighbour table entry (e.g. an entry in the ARP table)

--- a/rtnl/route.go
+++ b/rtnl/route.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/jsimonetti/rtnetlink/internal/unix"
+	"github.com/jsimonetti/rtnetlink/v2/internal/unix"
 
-	"github.com/jsimonetti/rtnetlink"
+	"github.com/jsimonetti/rtnetlink/v2"
 )
 
 // Route represents a route table entry

--- a/rtnl/route_options.go
+++ b/rtnl/route_options.go
@@ -3,7 +3,7 @@ package rtnl
 import (
 	"net"
 
-	"github.com/jsimonetti/rtnetlink"
+	"github.com/jsimonetti/rtnetlink/v2"
 )
 
 // RouteOptions is the functional options struct

--- a/rule.go
+++ b/rule.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"net"
 
-	"github.com/jsimonetti/rtnetlink/internal/unix"
+	"github.com/jsimonetti/rtnetlink/v2/internal/unix"
 	"github.com/mdlayher/netlink"
 )
 


### PR DESCRIPTION
In order to update to v2.0.0, we need to update the module path per the Go module documentation.
* https://go.dev/doc/modules/major-version

Fixes: https://github.com/jsimonetti/rtnetlink/issues/225

This can be released as v2.0.1