### PR TITLE
rtnetlink: fix Link ListByKind response

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -174,7 +174,7 @@ func unpackMessages(msgs []netlink.Message) ([]Message, error) {
 		var m Message
 		switch nm.Header.Type {
 		case unix.RTM_GETLINK, unix.RTM_NEWLINK, unix.RTM_DELLINK:
-			m = &LinkMessage{}
+			m = &LinkMessage{filtered: (nm.Header.Flags&netlink.DumpFiltered != 0)}
 		case unix.RTM_GETADDR, unix.RTM_NEWADDR, unix.RTM_DELADDR:
 			m = &AddressMessage{}
 		case unix.RTM_GETROUTE, unix.RTM_NEWROUTE, unix.RTM_DELROUTE:

--- a/link_live_test.go
+++ b/link_live_test.go
@@ -239,3 +239,24 @@ func TestLinkXDPReplace(t *testing.T) {
 		t.Fatal("XDP prog ID does match previous program ID, which it shouldn't")
 	}
 }
+
+func TestLinkListByKind(t *testing.T) {
+	if err := rlimit.RemoveMemlock(); err != nil {
+		t.Fatal(err)
+	}
+
+	conn, err := Dial(&netlink.Config{NetNS: testutils.NetNS(t)})
+	if err != nil {
+		t.Fatalf("failed to establish netlink socket: %v", err)
+	}
+	defer conn.Close()
+
+	links, err := conn.Link.ListByKind("SomeImpossibleLinkKind")
+	if err != nil {
+		t.Fatalf("LinkListByKind() finished with error: %v", err)
+	}
+
+	if len(links) > 0 {
+		t.Fatalf("LinkListByKind() found %d links with impossible kind", len(links))
+	}
+}


### PR DESCRIPTION
the linux kernel handles a RTM_GETLINK request even in case of incorrent kind filter. if it finds requested kind it responds with a list of this kind of links and marks every message in a response by NLM_F_DUMP_FILTERED flag. Otherwise it sends all available links w/o NLF_F_DUMP_FILTERED. So, looks much better to return to a callee empty link list if there are no links of requested kind.