### PR TITLE
feat: implement support for altnames

### DIFF
--- a/internal/unix/types_linux.go
+++ b/internal/unix/types_linux.go
@@ -107,6 +107,8 @@ const (
 	IFLA_LINKINFO                              = linux.IFLA_LINKINFO
 	IFLA_LINKMODE                              = linux.IFLA_LINKMODE
 	IFLA_IFALIAS                               = linux.IFLA_IFALIAS
+	IFLA_PROP_LIST                             = linux.IFLA_PROP_LIST
+	IFLA_ALT_IFNAME                            = linux.IFLA_ALT_IFNAME
 	IFLA_MASTER                                = linux.IFLA_MASTER
 	IFLA_CARRIER                               = linux.IFLA_CARRIER
 	IFLA_CARRIER_CHANGES                       = linux.IFLA_CARRIER_CHANGES

--- a/internal/unix/types_other.go
+++ b/internal/unix/types_other.go
@@ -103,6 +103,8 @@ const (
 	IFLA_LINKINFO                              = 0x12
 	IFLA_LINKMODE                              = 0x11
 	IFLA_IFALIAS                               = 0x14
+	IFLA_PROP_LIST                             = 0x34
+	IFLA_ALT_IFNAME                            = 0x35
 	IFLA_MASTER                                = 0xa
 	IFLA_CARRIER                               = 0x21
 	IFLA_CARRIER_CHANGES                       = 0x23


### PR DESCRIPTION
This properly list is used e.g. by `systemd-udevd` to provide other alternative names for predictable interface names.