### PR TITLE
feat: add support for address priority

### DIFF
--- a/address.go
+++ b/address.go
@@ -158,6 +158,7 @@ type AddressAttributes struct {
 	CacheInfo CacheInfo // Address information
 	Multicast net.IP    // Multicast Ip address
 	Flags     uint32    // Address flags
+	Priority  uint32    // Priority/metric for prefix route
 }
 
 func (a *AddressAttributes) decode(ad *netlink.AttributeDecoder) error {
@@ -181,6 +182,8 @@ func (a *AddressAttributes) decode(ad *netlink.AttributeDecoder) error {
 			ad.Do(decodeIP(&a.Multicast))
 		case unix.IFA_FLAGS:
 			a.Flags = ad.Uint32()
+		case unix.IFA_RT_PRIORITY:
+			a.Priority = ad.Uint32()
 		}
 	}
 
@@ -206,6 +209,9 @@ func (a *AddressAttributes) encode(ae *netlink.AttributeEncoder) error {
 		ae.String(unix.IFA_LABEL, a.Label)
 	}
 	ae.Uint32(unix.IFA_FLAGS, a.Flags)
+	if a.Priority != 0 {
+		ae.Uint32(unix.IFA_RT_PRIORITY, a.Priority)
+	}
 
 	return nil
 }

--- a/internal/unix/types_linux.go
+++ b/internal/unix/types_linux.go
@@ -39,6 +39,7 @@ const (
 	IFA_CACHEINFO                              = linux.IFA_CACHEINFO
 	IFA_MULTICAST                              = linux.IFA_MULTICAST
 	IFA_FLAGS                                  = linux.IFA_FLAGS
+	IFA_RT_PRIORITY                            = linux.IFA_RT_PRIORITY
 	IFF_UP                                     = linux.IFF_UP
 	IFF_BROADCAST                              = linux.IFF_BROADCAST
 	IFF_LOOPBACK                               = linux.IFF_LOOPBACK

--- a/internal/unix/types_other.go
+++ b/internal/unix/types_other.go
@@ -35,6 +35,7 @@ const (
 	IFA_CACHEINFO                              = 0x6
 	IFA_MULTICAST                              = 0x7
 	IFA_FLAGS                                  = 0x8
+	IFA_RT_PRIORITY                            = 0x9
 	IFF_UP                                     = 0x1
 	IFF_BROADCAST                              = 0x2
 	IFF_LOOPBACK                               = 0x8


### PR DESCRIPTION
This allows to set route priority/metric for prefix routes created automatically when an address is assigned.

E.g. `10.0.0.0/8` with metric `32` would generate a route:

```
10.0.0.0/8 via <if> metric 32
```

The default metric is zero. A custom metric allows to prefer one interface over another when the prefixes overlap.

See https://github.com/siderolabs/talos/issues/10696