### PR TITLE
feat(route): list with kernel filtering

### DIFF
--- a/route.go
+++ b/route.go
@@ -142,16 +142,22 @@ func (r *RouteService) Delete(req *RouteMessage) error {
 	return err
 }
 
-// Get Route(s)
+// Get Route(s).
 func (r *RouteService) Get(req *RouteMessage) ([]RouteMessage, error) {
-	flags := netlink.Request | netlink.DumpFiltered
+	flags := netlink.Request
 	return r.execute(req, unix.RTM_GETROUTE, flags)
 }
 
 // List all routes
 func (r *RouteService) List() ([]RouteMessage, error) {
+	return r.ListMatch(&RouteMessage{})
+}
+
+// List matching Route(s). For attributes to be included as part of the match filter the
+// netlink connection must be in strict mode.
+func (r *RouteService) ListMatch(req *RouteMessage) ([]RouteMessage, error) {
 	flags := netlink.Request | netlink.Dump
-	return r.execute(&RouteMessage{}, unix.RTM_GETROUTE, flags)
+	return r.execute(req, unix.RTM_GETROUTE, flags)
 }
 
 type RouteAttributes struct {

--- a/route_live_test.go
+++ b/route_live_test.go
@@ -1,0 +1,39 @@
+//go:build integration
+// +build integration
+
+package rtnetlink
+
+import (
+	"testing"
+
+	"github.com/jsimonetti/rtnetlink/v2/internal/unix"
+	"github.com/mdlayher/netlink"
+)
+
+func TestListMatch(t *testing.T) {
+	c, err := Dial(&netlink.Config{Strict: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	routes, err := c.Route.ListMatch(&RouteMessage{
+		Family: unix.AF_INET,
+		Attributes: RouteAttributes{
+			Table: unix.RT_TABLE_MAIN,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(routes) <= 1 {
+		t.Fatal("expected multiple routes to be returned")
+	}
+
+	for _, rx := range routes {
+		if rx.Attributes.Table != unix.RT_TABLE_MAIN {
+			t.Fatalf("unepxected route from table %d", rx.Attributes.Table)
+		}
+	}
+}


### PR DESCRIPTION
A new "ListMatch" function has been added to the RouteService to allow for kernel-based filtering of the routing tables. The netlink flags required for getting a route for an IP (eg, rtnl.RouteGetAll) is different than those required while filtering the table.

This changeset removes the superfluous "netlink.DumpFiltered" flag from the Get function of RouteService, as this flag is for kernel responses.