### PR TITLE
Use golang.org/x/sys/cpu.IsBigEndian

### DIFF
--- a/address_test.go
+++ b/address_test.go
@@ -1,13 +1,12 @@
 package rtnetlink
 
 import (
-	"encoding/binary"
 	"net"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/jsimonetti/rtnetlink/v2/internal/unix"
-	"github.com/mdlayher/netlink/nlenc"
+	"golang.org/x/sys/cpu"
 )
 
 func TestAddressMessageMarshalBinary(t *testing.T) {
@@ -183,7 +182,7 @@ func TestAddressMessageUnmarshalBinary(t *testing.T) {
 }
 
 func skipBigEndian(t *testing.T) {
-	if nlenc.NativeEndian() == binary.BigEndian {
+	if cpu.IsBigEndian {
 		t.Skip("skipping test on big-endian system")
 	}
 }


### PR DESCRIPTION
github.com/mdlayher/netlink v1.8.0 changed the return of nlenc.NativeEndian() such that comparing it against encoding.BigEndian or encoding.LittleEndian does not work as expected.

See https://github.com/mdlayher/netlink/pull/220#issuecomment-3225094532